### PR TITLE
Added Robot Framework invoice example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ examples and descriptions.
 ## All available examples
 
 * [Find statistical relationships within traffic violations](./traffic-violations)
-* [Predict missing values in Robot Framework](./) UNDER CONSTRUCTION
+* [Predict missing values in Robot Framework](./roboframework-invoice)
 
 We gladly accept requests for additional examples, if you have an idea on something you would like to see in our
 gallery. Please create a pull-request with an example, an issue with an idea for one, or contact us using the

--- a/roboframework-invoice/README.md
+++ b/roboframework-invoice/README.md
@@ -1,0 +1,5 @@
+# Machine Learning in Robot Framework
+
+This example walks through how to implement machine learning predictions easily in [Robot Framework](https://robotframework.org/rpa/) RPA framework, using a purchase invoice dataset as an example. The use case is to predict missing datapoints in new invoices.
+
+Step by step instructions are in the [blog post](https://aito.ai/blog/machine-learning-in-robot-framework/), please follow that in order to replicate this example.

--- a/roboframework-invoice/aitohelper.robot
+++ b/roboframework-invoice/aitohelper.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Documentation     A resource file with reusable keywords and variables for using Aito.
+...
+...               The system specific keywords created here form our own
+...               domain specific language. They utilize keywords provided
+...               by the imported AitoClient.
+Library     aito.sdk.aito_client.AitoClient     %{AITO_INSTANCE_URL}     %{AITO_API_KEY}    False
+Library     Collections
+
+*** Keywords ***
+Aito Predict
+    [Arguments]    ${table}    ${inputs}    ${target}    ${limit}=1
+    # table: String, name of the table in Aito schema
+    # inputs: Dictionary, input data for prediction
+    # target: String, name of the feature being predicted
+    # limit: Integer, how many entries Aito returns
+
+    # Ensure inputs are in correct format
+    ${limit}=   Convert To Integer  ${limit}
+
+    # Remove target feature from inputs if exists
+    Remove From Dictionary      ${inputs}       ${target}
+
+    # Construct predict query body as a Dictionary using arguments
+    ${query}=       Create Dictionary   from=${table}   where=${inputs}   predict=${target}   limit=${limit}
+
+    # Query from Aito
+    ${response}=    Request              POST    /api/v1/_predict     ${query}
+
+    # Return only first feature and probability
+    [Return]  ${response['hits'][0]['feature']}  ${response['hits'][0]['$p']}
+
+Aito Upload
+    [Arguments]     ${table}        ${inputs}
+    # table: String, name of the table in Aito schema
+    # inputs: Dictionary, input data for prediction
+
+    ${endpoint}=    Catenate    SEPARATOR=    /api/v1/data/       ${table}
+    ${response}=    Request         POST        ${endpoint}   ${inputs}
+    [Return]        ${response}
+

--- a/roboframework-invoice/files/categorized/invoice2.json
+++ b/roboframework-invoice/files/categorized/invoice2.json
@@ -1,0 +1,7 @@
+{'Inv_Id': 15021,
+ 'Vendor_Code': 'VENDOR-1065',
+ 'GL_Code': 'GL-6050310',
+ 'Inv_Amt': 35.73,
+ 'Item_Description': 'Travel Car',
+ 'Product_Category': 'CLASS-1429'
+}

--- a/roboframework-invoice/files/invoice1.json
+++ b/roboframework-invoice/files/invoice1.json
@@ -1,0 +1,7 @@
+{
+ 'Inv_Id': 15014,
+ 'Vendor_Code': 'VENDOR-2513',
+ 'GL_Code': 'GL-6050310',
+ 'Inv_Amt': 69.85,
+ 'Item_Description': 'Ground Transportation'
+}

--- a/roboframework-invoice/files/invoice2.json
+++ b/roboframework-invoice/files/invoice2.json
@@ -1,0 +1,7 @@
+{'Inv_Id': 15021,
+ 'Vendor_Code': 'VENDOR-1065',
+ 'GL_Code': 'GL-6050310',
+ 'Inv_Amt': 35.73,
+ 'Item_Description': 'Travel Car',
+ 'Product_Category': 'CLASS-1429'
+}

--- a/roboframework-invoice/files/invoice3.txt
+++ b/roboframework-invoice/files/invoice3.txt
@@ -1,0 +1,6 @@
+{'Inv_Id': 15033,
+ 'Vendor_Code': 'VENDOR-1424',
+ 'GL_Code': 'GL-6100410',
+ 'Inv_Amt': 78.78,
+ 'Item_Description': 'Digital Display'
+}

--- a/roboframework-invoice/files/invoice4.json
+++ b/roboframework-invoice/files/invoice4.json
@@ -1,0 +1,6 @@
+{'Inv_Id': 15058,
+ 'Vendor_Code': 'VENDOR-1883',
+ 'GL_Code': 'GL-2182000',
+ 'Inv_Amt': 18.88,
+ 'Item_Description': 'Auto Leasing and Maintenance'
+}

--- a/roboframework-invoice/files/invoice5.txt
+++ b/roboframework-invoice/files/invoice5.txt
@@ -1,0 +1,6 @@
+{'Inv_Id': 15058,
+ 'Vendor_Code': 'VENDOR-1883',
+ 'GL_Code': 'GL-2182000',
+ 'Inv_Amt': 18.88,
+ 'Item_Description': 'Auto Leasing and Maintenance'
+}

--- a/roboframework-invoice/invoice.robot
+++ b/roboframework-invoice/invoice.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Documentation     Invoice categorization with Aito.
+...
+Library     OperatingSystem
+Resource    aitohelper.robot
+
+*** Variables ***
+${table}=       invoice_data        # Name of table in Aito insance
+${target}=      Product_Category    # Name of the feature we want to predict
+${path}=        ./files
+${pathCate}=    ./files/categorized
+
+*** Test Cases ***
+
+Categorize Invoices
+    # Loop through all files in directory
+    ${files}=                   List Files In Directory     ${path}
+    FOR     ${fileName}         IN              @{files}
+        
+        # Read file
+        ${filePath}=            Join Path       ${path}     ${fileName}
+        ${data}=                Get File        ${filePath}
+
+        # Turn file content into a dictionary and check if target exists in dictionary
+        ${data}=                Evaluate        ${data}
+        ${exists}=              Evaluate        '${target}' in ${data}                 
+
+        # If target does not exist in dictionary, predict the most probable value
+        ${pred}   ${prob} =     Run Keyword Unless              ${exists}     Aito Predict      ${table}    ${data}      ${target}
+        
+        # If target exists in dictionary and no need to predict, upload dictionary into Aito
+        Run Keyword If          ${exists}     Aito Upload       ${table}    ${data}
+        
+        # If prediction was made, add predicted value to dictionary
+        Run Keyword Unless      ${exists}     Set To Dictionary    ${data}    ${target}   ${pred}
+ 
+        # Convert dictionary to string and write into a file
+        ${data}=                Convert To String   ${data}
+        ${filePath}=            Join Path       ${pathCate}    ${fileName}
+        Create File             ${filePath}     ${data}
+    END


### PR DESCRIPTION
Added files to support the blog post example, and edited the main readme.md file to contain this example. Note the main csv datafile is in datasets/invoice-automation folder, whereas all the files relevant to this example are in separate folder.

No step-by-step instructions included in the examples readme.md file, so that we don't have two places to maintain.